### PR TITLE
Add heading links example

### DIFF
--- a/views/elements/typography/home.hbs
+++ b/views/elements/typography/home.hbs
@@ -89,6 +89,20 @@
       </ol>
 
 
+      <h2 class="heading-medium">Link headings (with descriptions)</h2>
+
+      <ol>
+        <li>
+          <h3 class="heading-medium"><a href="#">Integer posuere erat</a></h3>
+          <p>Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+        </li>
+        <li>
+          <h3 class="heading-medium"><a href="#">Venenatis dapibus posuere</a></h3>
+          <p>Vestibulum id ligula porta felis euismod semper.</p>
+        </li>
+      </ol>
+
+
       <h2 class="heading-medium">External links (Screen reader optimised)</h2>
 
       <p><a href="https://www.gov.uk" rel="external">Visit gov.uk</a></p>


### PR DESCRIPTION
@trevorsaint  - The developers needed an example of this for the internal interface. I thought I'd take the opportunity to try out the styleguide. I've based the code on the GOV.UK category pages, but feel free to change if you want.